### PR TITLE
add warm start attribute to HpBandSterSearchCV, so that the user can choose whether to warm start

### DIFF
--- a/hpbandster_sklearn/HpBandSterSearchCV.py
+++ b/hpbandster_sklearn/HpBandSterSearchCV.py
@@ -503,7 +503,7 @@ class HpBandSterSearchCV(BaseSearchCV):
                     cv_n_splits=n_splits,
                     groups=groups,
                     scoring=scorers,
-                    warm_start = self.warm_start
+                    warm_start=self.warm_start,
                     metric=refit_metric,
                     fit_params=fit_params,
                     nameserver=self.nameserver_host,

--- a/hpbandster_sklearn/HpBandSterSearchCV.py
+++ b/hpbandster_sklearn/HpBandSterSearchCV.py
@@ -135,6 +135,11 @@ class HpBandSterSearchCV(BaseSearchCV):
         A single string (see `scoring_parameter`) or a callable
         (see `scoring`) to evaluate the predictions on the test set.
         If None, the estimator's score method is used.
+    
+    warm_start : bool, default=True
+        if estimator has attribute of 'warm_start' and 'warm_start'=True,
+        the fitting process will reuse the solution of the previous call to fit
+        otherwise just fit a whole estimator.
 
     refit : bool, default=True
         If True, refit an estimator using the best found parameters on the
@@ -297,6 +302,7 @@ class HpBandSterSearchCV(BaseSearchCV):
         resource_type=None,
         cv=None,
         scoring=None,
+        warm_start=True,
         refit=True,
         error_score=np.nan,
         return_train_score=False,
@@ -334,6 +340,7 @@ class HpBandSterSearchCV(BaseSearchCV):
         self.max_budget = max_budget
         self.resource_name = resource_name
         self.resource_type = resource_type
+        self.warm_start = warm_start
         self.random_state = random_state
         self.optimizer = optimizer
         self.nameserver_port = nameserver_port
@@ -496,6 +503,7 @@ class HpBandSterSearchCV(BaseSearchCV):
                     cv_n_splits=n_splits,
                     groups=groups,
                     scoring=scorers,
+                    warm_start = self.warm_start
                     metric=refit_metric,
                     fit_params=fit_params,
                     nameserver=self.nameserver_host,

--- a/hpbandster_sklearn/SklearnWorker.py
+++ b/hpbandster_sklearn/SklearnWorker.py
@@ -347,6 +347,7 @@ class SklearnWorker(Worker):
         min_budget=0,
         max_budget=1,
         scoring=None,
+        warm_start=True,
         metric="score",
         resource_name=None,
         resource_type=None,
@@ -395,6 +396,7 @@ class SklearnWorker(Worker):
         self.X = X
         self.y = y
         self.scoring = scoring
+        self.warm_start = warm_start
         self.metric = metric
         self.cv = cv
         self.cv_n_splits = cv_n_splits
@@ -458,7 +460,7 @@ class SklearnWorker(Worker):
             try:
                 if not is_catboost_model(self.actual_base_estimator):
                     self.base_estimator.set_params(
-                        **{f"{self.actual_estimator_name_prefix}warm_start": True}
+                        **{f"{self.actual_estimator_name_prefix}warm_start": self.warm_start}
                     )
             except:
                 pass


### PR DESCRIPTION
https://github.com/Yard1/hpbandster-sklearn/issues/6
add warm start attribute to HpBandSterSearchCV, so that the user can choose whether to warm start

**warm_start = True(default)**

code
---

import numpy as np
from sklearn.datasets import load_iris
from sklearn.ensemble import RandomForestClassifier
from hpbandster_sklearn import HpBandSterSearchCV
from sklearn.model_selection import KFold, cross_val_score

import ConfigSpace as CS
import ConfigSpace.hyperparameters as CSH

X, y = load_iris(return_X_y=True)
clf = RandomForestClassifier(n_estimators=10, random_state=0)  
kf = KFold(shuffle=False)

param_distributions = CS.ConfigurationSpace(seed=0)
param_distributions.add_hyperparameter(CSH.UniformIntegerHyperparameter("min_samples_split", 2, 11))
param_distributions.add_hyperparameter(CSH.UniformIntegerHyperparameter("max_depth", 2, 4))

search = HpBandSterSearchCV(clf, param_distributions, resource_name='n_estimators', min_budget=10, max_budget=80,
                            random_state=0, n_jobs=1,cv=kf, warm_start=True,
                            n_iter=4, **{'eta':2}).fit(X, y)

for p, s, c in zip(search.cv_results_['params'], search.cv_results_['n_resources'], search.cv_results_['mean_test_score']):
    params = p
    params['n_estimators'] = s
    clf = clf.set_params(**params)
    
    print(params)
    print(np.mean(cross_val_score(clf , X, y, cv=kf)), c)

output：Some are different due to warm start 
---
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 10, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 10, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 4, 'min_samples_split': 5, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 4, 'min_samples_split': 7, 'n_estimators': 10}
0.9133333333333333 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 11, 'n_estimators': 20}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 11, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 11, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 20}
**0.9133333333333333 0.9066666666666666**(inequality)
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 6, 'n_estimators': 20}
**0.9133333333333333 0.9066666666666666**(inequality)
{'max_depth': 2, 'min_samples_split': 2, 'n_estimators': 20}
**0.9133333333333333 0.9066666666666666**(inequality)
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 10, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 2, 'n_estimators': 40}
**0.9 0.9066666666666666**(inequality)
{'max_depth': 2, 'min_samples_split': 10, 'n_estimators': 80}
**0.9066666666666666 0.9**(inequality)
{'max_depth': 3, 'min_samples_split': 11, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 80}
0.9 0.9
{'max_depth': 4, 'min_samples_split': 10, 'n_estimators': 80}
0.9 0.9

**warm_start = False**

code
---
import numpy as np
from sklearn.datasets import load_iris
from sklearn.ensemble import RandomForestClassifier
from hpbandster_sklearn import HpBandSterSearchCV
from sklearn.model_selection import KFold, cross_val_score

import ConfigSpace as CS
import ConfigSpace.hyperparameters as CSH

X, y = load_iris(return_X_y=True)
clf = RandomForestClassifier(n_estimators=10, random_state=0)  
kf = KFold(shuffle=False)

param_distributions = CS.ConfigurationSpace(seed=0)
param_distributions.add_hyperparameter(CSH.UniformIntegerHyperparameter("min_samples_split", 2, 11))
param_distributions.add_hyperparameter(CSH.UniformIntegerHyperparameter("max_depth", 2, 4))

search = HpBandSterSearchCV(clf, param_distributions, resource_name='n_estimators', min_budget=10, max_budget=80,
                            random_state=0, n_jobs=1,cv=kf, warm_start=False,
                            n_iter=4, **{'eta':2}).fit(X, y)

for p, s, c in zip(search.cv_results_['params'], search.cv_results_['n_resources'], search.cv_results_['mean_test_score']):
    params = p
    params['n_estimators'] = s
    clf = clf.set_params(**params)
    
    print(params)
    print(np.mean(cross_val_score(clf , X, y, cv=kf)), c)

output：All the same
---
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 10, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 10, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 4, 'min_samples_split': 5, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 4, 'min_samples_split': 7, 'n_estimators': 10}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 10}
0.9199999999999999 0.9199999999999999
{'max_depth': 3, 'min_samples_split': 11, 'n_estimators': 20}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 6, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 6, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 2, 'min_samples_split': 2, 'n_estimators': 20}
0.9133333333333333 0.9133333333333333
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 11, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 9, 'n_estimators': 40}
0.9066666666666666 0.9066666666666666
{'max_depth': 2, 'min_samples_split': 10, 'n_estimators': 80}
0.9066666666666666 0.9066666666666666
{'max_depth': 3, 'min_samples_split': 7, 'n_estimators': 80}
0.9 0.9
{'max_depth': 3, 'min_samples_split': 8, 'n_estimators': 80}
0.9 0.9
{'max_depth': 4, 'min_samples_split': 10, 'n_estimators': 80}
0.9 0.9

