### PR TITLE
Use the best resource value instead of the biggest

### DIFF
--- a/hpbandster_sklearn/HpBandSterSearchCV.py
+++ b/hpbandster_sklearn/HpBandSterSearchCV.py
@@ -631,7 +631,7 @@ class HpBandSterSearchCV(BaseSearchCV):
             # of the params are estimators as well.
             refit_params = self.best_params_.copy()
             if self.resource_name_ != "n_samples":
-                refit_params[self.resource_name_] = self.max_resources_
+                refit_params[self.resource_name_] = results['n_resources'][self.best_index_]
             self.best_estimator_ = clone(
                 clone(base_estimator).set_params(**refit_params)
             )

--- a/hpbandster_sklearn/HpBandSterSearchCV.py
+++ b/hpbandster_sklearn/HpBandSterSearchCV.py
@@ -631,7 +631,7 @@ class HpBandSterSearchCV(BaseSearchCV):
             # of the params are estimators as well.
             refit_params = self.best_params_.copy()
             if self.resource_name_ != "n_samples":
-                refit_params[self.resource_name_] = results['n_resources'][self.best_index_]
+                refit_params[self.resource_name_] = results["n_resources"][self.best_index_]
             self.best_estimator_ = clone(
                 clone(base_estimator).set_params(**refit_params)
             )

--- a/hpbandster_sklearn/SklearnWorker.py
+++ b/hpbandster_sklearn/SklearnWorker.py
@@ -46,14 +46,14 @@ class _SubsampleMetaSplitter:
 
     def split(self, X, y, groups=None):
         for train_idx, test_idx in self.base_cv.split(X, y, groups):
-            train_idx = resample(
-                train_idx,
-                replace=False,
-                random_state=self.random_state,
+            if self.fraction < 1:train_idx = resample(           # when self.fraction=1, which means to use the entire train_idx.
+                train_idx,                                       # If sampling randomly, the order of samples will be changed, which means                               
+                replace=False,                                   # their corresponding samples are the same, but the order is different.
+                random_state=self.random_state,                  # This will affect model like random forest, which is sensitive to the sample order.
                 n_samples=int(ceil(self.fraction * train_idx.shape[0])),
             )
             if self.subsample_test:
-                test_idx = resample(
+                if self.fraction < 1:test_idx = resample(
                     test_idx,
                     replace=False,
                     random_state=self.random_state,

--- a/hpbandster_sklearn/SklearnWorker.py
+++ b/hpbandster_sklearn/SklearnWorker.py
@@ -46,19 +46,21 @@ class _SubsampleMetaSplitter:
 
     def split(self, X, y, groups=None):
         for train_idx, test_idx in self.base_cv.split(X, y, groups):
-            if self.fraction < 1:train_idx = resample(           # when self.fraction=1, which means to use the entire train_idx.
-                train_idx,                                       # If sampling randomly, the order of samples will be changed, which means                               
-                replace=False,                                   # their corresponding samples are the same, but the order is different.
-                random_state=self.random_state,                  # This will affect model like random forest, which is sensitive to the sample order.
-                n_samples=int(ceil(self.fraction * train_idx.shape[0])),
-            )
-            if self.subsample_test:
-                if self.fraction < 1:test_idx = resample(
-                    test_idx,
-                    replace=False,
-                    random_state=self.random_state,
-                    n_samples=int(ceil(self.fraction * test_idx.shape[0])),
+            if self.fraction < 1:
+                train_idx = resample(                                # when self.fraction=1, which means to use the entire train_idx.
+                    train_idx,                                       # If sampling randomly, the order of samples will be changed, which means
+                    replace=False,                                   # their corresponding samples are the same, but the order is different.
+                    random_state=self.random_state,                  # This will affect model like random forest, which is sensitive to the sample order.
+                    n_samples=int(ceil(self.fraction * train_idx.shape[0])),
                 )
+            if self.subsample_test:
+                if self.fraction < 1:
+                    test_idx = resample(
+                        test_idx,
+                        replace=False,
+                        random_state=self.random_state,
+                        n_samples=int(ceil(self.fraction * test_idx.shape[0])),
+                    )
             yield train_idx, test_idx
 
 


### PR DESCRIPTION
https://github.com/Yard1/hpbandster-sklearn/issues/5

when resource_name != "n_samples", resource_name  is the hyperparameter of estimator.
`refit_params[self.resource_name_] = self.max_resources_`
code above means the best performance is at max_resources_.
but good performance is clearly in the search process, not at the end.
so, I modified it as below.
`refit_params[self.resource_name_] = results['n_resources'][self.best_index_]`